### PR TITLE
Add GC content calculator script and results

### DIFF
--- a/gc_content_calculator.sh
+++ b/gc_content_calculator.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# Check if the input file is provided
+if [[ $# -eq 0 ]]; then
+    echo "Usage: ./gc_content_calculator.sh <fasta_file>"
+    exit 1
+fi
+
+fasta_file=$1
+output_file="gc_content_results.txt"
+
+# Initialize variables
+sequence_name=""
+sequence_content=""
+
+# Clear the output file if it exists
+> "$output_file"
+
+# Process each line in the FASTA file
+while read -r line; do
+    case "$line" in
+        '>'*)
+            # If a sequence is already being processed, calculate its GC content
+            if [[ -n $sequence_content ]]; then
+                gc_count=$(echo "$sequence_content" | grep -o '[GC]' | wc -l)
+                total_count=$(echo "$sequence_content" | tr -d '\n' | wc -c)
+                gc_content=$(echo "scale=2; ($gc_count/$total_count)*100" | bc)
+                echo "$sequence_name: $gc_content%" >> "$output_file"
+            fi
+            # Start processing a new sequence
+            sequence_name=$line
+            sequence_content=""
+            ;;
+        *)
+            # Append the current line to the sequence content
+            sequence_content+=$line
+            ;;
+    esac
+done < "$fasta_file"
+
+# Process the last sequence in the file
+if [[ -n $sequence_content ]]; then
+    gc_count=$(echo "$sequence_content" | grep -o '[GC]' | wc -l)
+    total_count=$(echo "$sequence_content" | tr -d '\n' | wc -c)
+    gc_content=$(echo "scale=2; ($gc_count/$total_count)*100" | bc)
+    echo "$sequence_name: $gc_content%" >> "$output_file"
+fi
+
+echo "GC content for each sequence saved to $output_file"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      
+
+
+
+
+
+
+
+
+
+
+
+

--- a/gc_content_results.txt
+++ b/gc_content_results.txt
@@ -1,0 +1,10 @@
+>OM938458.1 UNVERIFIED: Bemisia tabaci isolate WF-21 cytochrome oxidase subunit 1-like (COI) gene, partial sequence; mitochondrial: 33.00%
+>OM938457.1 UNVERIFIED: Bemisia tabaci isolate wf-10 cytochrome oxidase subunit 1-like (COI) gene, partial sequence; mitochondrial: 32.00%
+>MN989602.1 Bemisia tabaci isolate SMW-4 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 32.00%
+>MN989601.1 Bemisia tabaci isolate SMW-3 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 32.00%
+>MN989600.1 Bemisia tabaci isolate SMW-30 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 32.00%
+>MN989599.1 Bemisia tabaci isolate SMW-28 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 33.00%
+>MN989598.1 Bemisia tabaci isolate SMW-12 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 33.00%
+>MN989597.1 Bemisia tabaci isolate SMW-10 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 33.00%
+>MN989596.1 Bemisia tabaci isolate SMW-9 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 32.00%
+>MN989595.1 Bemisia tabaci isolate SMW-25 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 33.00%


### PR DESCRIPTION
Added GC content calculator script and results
>OM938458.1 UNVERIFIED: Bemisia tabaci isolate WF-21 cytochrome oxidase subunit 1-like (COI) gene, partial sequence; mitochondrial: 33.00%
>OM938457.1 UNVERIFIED: Bemisia tabaci isolate wf-10 cytochrome oxidase subunit 1-like (COI) gene, partial sequence; mitochondrial: 32.00%
>MN989602.1 Bemisia tabaci isolate SMW-4 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 32.00%
>MN989601.1 Bemisia tabaci isolate SMW-3 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 32.00%
>MN989600.1 Bemisia tabaci isolate SMW-30 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 32.00%
>MN989599.1 Bemisia tabaci isolate SMW-28 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 33.00%
>MN989598.1 Bemisia tabaci isolate SMW-12 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 33.00%
>MN989597.1 Bemisia tabaci isolate SMW-10 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 33.00%
>MN989596.1 Bemisia tabaci isolate SMW-9 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 32.00%
>MN989595.1 Bemisia tabaci isolate SMW-25 cytochrome oxidase subunit I (COI) gene, partial cds; mitochondrial: 33.00%